### PR TITLE
Update event locationUrl

### DIFF
--- a/public/events.json
+++ b/public/events.json
@@ -4,7 +4,7 @@
     "title": "#1: PJ Evans & Junade Ali",
     "description": "We are thrilled to invite you to the inaugural event of our new series of events! Join us for an insightful talks, networking opportunities, and talks by very special guests. Save the date and be part of this community!",
     "location": "Vulcan Works, 34-38 Guildhall Rd, Northampton, NN1 1EW",
-    "locationUrl": "https://vulcanworks.co.uk",
+    "locationUrl": "https://maps.app.goo.gl/q7RFeDME5cLZWPFA7",
     "date": "2024-03-27T18:00Z",
     "price": "FREE (Eventbrite registration required)",
     "parking": "St. John's Multi Storey Car Park",


### PR DESCRIPTION
When we travelled to the event we easily found the car park, due to the Google Maps link. Finding the venue was slightly more tricky as it linked to the website URL, rather than google maps.