### PR TITLE
Update text colour

### DIFF
--- a/components/Event.tsx
+++ b/components/Event.tsx
@@ -136,7 +136,7 @@ function Event({
             key={index}
             className="flex flex-col gap-2 py-4 sm:gap-6 sm:flex-row border-b border-zinc-800"
           >
-            <p className="w-32 font-normal text-gray-500  dark:text-zinc-100 shrink-0">
+            <p className="w-32 font-normal text-zinc-400  dark:text-zinc-100 shrink-0">
               {scheduleItem.time}
             </p>
 


### PR DESCRIPTION
Text colour for event timings has poor colour contrast so I've made it a bit lighter to match the rest of the greys.

**Before**
<img width="400" alt="Screenshot 2024-04-02 at 12 19 54" src="https://github.com/nn1-dev/website/assets/182101/f12e79cc-0b17-42f7-9433-d840af5eb186">

**After**
<img width="389" alt="Screenshot 2024-04-02 at 12 19 33" src="https://github.com/nn1-dev/website/assets/182101/740a10e4-4ee6-4d01-830a-c8ac10709079">
