### PR TITLE
Update home link

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -11,6 +11,8 @@ function Nav() {
             viewBox="0 0 102 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
+            role="img"
+            aria-label="NN1 Home"
           >
             <path
               fillRule="evenodd"


### PR DESCRIPTION
No alt tag on the home page logo.

W3C recommend to add an alt tag to say it's a link to the home page https://www.w3.org/WAI/tutorials/images/functional/#example-1-image-used-alone-as-a-linked-logo

As this is an SVG we have to use role="img" and aria-label="" as recommended here https://stackoverflow.com/a/4756461

