### PR TITLE
Resize contributer images

### DIFF
--- a/src/components/Connect.astro
+++ b/src/components/Connect.astro
@@ -35,7 +35,7 @@ const contributorsMap = contributors.map((user) => ({
                 class="connect__contributor-link"
               >
                 <Image
-                  src={contributor.avatar}
+                  src={`${contributor.avatar}&size=84`}
                   alt={`${contributor.username} on GitHub`}
                   class="connect__contributor-image"
                   width="42"


### PR DESCRIPTION
This change loads the profile image from Github at 2x size, rather than 400px.

I wonder if you can pass the image reference into Image and it will resize for us though? This probably ok for now.