### PR TITLE
fix: use minmax to keep grid columns equal

### DIFF
--- a/src/sections/Spotllight.astro
+++ b/src/sections/Spotllight.astro
@@ -64,11 +64,11 @@ const allSpotlights = await getCollection("spotlight");
     gap: var(--lh);
 
     @media (800px <= width) {
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     @media (1100px <= width) {
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 


### PR DESCRIPTION
Using minmax lets grid columns shrink properly. Without it, long content can force them wider and break the layout. [minmax](https://developer.mozilla.org/en-US/docs/Web/CSS/minmax)

Fixes #107 

![colsfix](https://github.com/user-attachments/assets/55b7b682-3281-4209-9aa8-15ca7dbb9b04)