### PR TITLE
Fixed responsiveness issues I responsiveness on the Spotlight page.  

### DIFF
--- a/src/sections/Spotllight.astro
+++ b/src/sections/Spotllight.astro
@@ -62,6 +62,7 @@ const allSpotlights = await getCollection("spotlight");
   .events__grid {
     display: grid;
     gap: var(--lh);
+    grid-template-columns: repeat(1, minmax(0, 1fr));
 
     @media (800px <= width) {
       grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Now, we have as expected 
Mobile:
![Screenshot from 2025-04-26 20-09-31](https://github.com/user-attachments/assets/8c65d86a-0d29-4e16-98cb-c45f219d8242)

Tablet:
![Screenshot from 2025-04-26 20-10-14](https://github.com/user-attachments/assets/9a7707e9-0a1f-416c-8d3a-467b0e19fd8b)

Closes #111 

Once again, apologies for not testing before pushing. 