### PR TITLE
Add Twitter/ X.com link to Spotlight content

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -77,6 +77,7 @@ const spotlight = defineCollection({
       urlBluesky: z.string().url().optional(),
       urlLinkedIn: z.string().url().optional(),
       urlInstagram: z.string().url().optional(),
+      urlTwitter: z.string().url().optional(),
     }),
 });
 

--- a/src/pages/spotlight/[spotlightId]/index.astro
+++ b/src/pages/spotlight/[spotlightId]/index.astro
@@ -43,6 +43,7 @@ const {
     urlBluesky,
     urlLinkedIn,
     urlInstagram,
+    urlTwitter,
   },
 } = entry;
 
@@ -189,6 +190,27 @@ const { Content, headings } = await render(entry);
                         />
                       </svg>
                       <span class="socials__label">Instagram</span>
+                    </a>
+                  </li>
+                ) : null
+              }
+              {
+                urlTwitter ? (
+                  <li class="socials_item">
+                    <a href={urlTwitter} class="socials__link">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="1200"
+                        height="1227"
+                        viewBox="0 0 1200 1227"
+                        class="socials__icon"
+                      >
+                        <path
+                          fill="currentColor"
+                          d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z"
+                        />
+                      </svg>
+                      <span class="socials__label">Twitter</span>
                     </a>
                   </li>
                 ) : null


### PR DESCRIPTION
Spotted that speakers can have Twitter links (e.g. https://github.com/nn1-dev/website/blob/main/src/data/speakers/matthew-owen.json#L8), but Spotlight seems not to have it?

Anyways, easy fix.

...I kept it worded as "Twitter" even though the icon is "X" - just as the Speaker link still says "Twitter" as well.

<img width="570" alt="Screenshot 2025-04-30 at 22 52 50" src="https://github.com/user-attachments/assets/14deb436-7606-47bb-8043-ead37648153b" />

<img width="558" alt="Screenshot 2025-04-30 at 22 52 57" src="https://github.com/user-attachments/assets/f2fda029-5cb2-4439-bd8b-eaa9889630bb" />
