### PR TITLE
Switch to toLocaleString and add timeZone option

### DIFF
--- a/src/pages/events/[eventId]/[ticketId]/[token]/index.astro
+++ b/src/pages/events/[eventId]/[ticketId]/[token]/index.astro
@@ -67,7 +67,8 @@ const inviteUrls = getInviteUrls({
   dateEnd,
 });
 
-const dateStartParsed = dateStart.toLocaleDateString("en-GB", {
+const dateStartParsed = dateStart.toLocaleString("en-GB", {
+  timeZone: "Europe/London",
   weekday: "long",
   year: "numeric",
   month: "2-digit",


### PR DESCRIPTION
Fixes bug where email with incorrect date would be sent out when run in non BST Cloudflare workers region.